### PR TITLE
Fix compatibility issue with Openfire 4.9.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -42,6 +42,13 @@
 
 <h1>Push Server Plugin Changelog</h1>
 
+<p><b>1.1.0</b> -- (tbd)</p>
+
+<ul>
+    <li>Now requires Openfire 4.8.0 or later.</li>
+    <li>[<a href="https://github.com/igniterealtime/openfire-pushserver-plugin/issues/18">#18</a>] - Fix compatibility issue with Openfire 4.9.0.</li>
+</ul>
+
 <p><b>1.0.0</b> -- Sep 16, 2022</p>
 
 <ul>

--- a/plugin.xml
+++ b/plugin.xml
@@ -7,11 +7,9 @@
     <version>${project.version}</version>
 
     <author>Busoft Teknoloji A.Ş.</author>
-    <date>09/02/2021</date>
+    <date>2024-09-11</date>
 
-    <minJavaVersion>1.8</minJavaVersion>
-
-    <minServerVersion>4.3.0</minServerVersion>
+    <minServerVersion>4.8.0</minServerVersion>
 
     <databaseKey>pushserver</databaseKey>
     <databaseVersion>1</databaseVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0</version>
+        <version>4.8.0</version>
     </parent>
 
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>pushserver</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -52,7 +52,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>1.8</jvmTarget>
+                    <jvmTarget>11</jvmTarget>
                 </configuration>
             </plugin>
             <!-- Compiles the Openfire Admin Console JSP pages. -->

--- a/src/java/org/igniterealtime/openfire/plugins/pushserver/PushServerProperty.kt
+++ b/src/java/org/igniterealtime/openfire/plugins/pushserver/PushServerProperty.kt
@@ -22,8 +22,8 @@ class PushServerProperty: PropertyEventListener {
     companion object {
         val serviceName = JiveGlobals.getProperty("pushserver.name", "push")
 
-        val FCM_CREDENTIAL_FILE_PATH = "${JiveGlobals.getHomeDirectory()}${File.separator}conf${File.separator}pushserver-fcm.json"
-        val APNS_PKCS8_FILE_PATH = "${JiveGlobals.getHomeDirectory()}${File.separator}conf${File.separator}pushserver-apns.p8"
+        val FCM_CREDENTIAL_FILE_PATH = "${JiveGlobals.getHomePath().resolve("conf").resolve("pushserver-fcm.json")}"
+        val APNS_PKCS8_FILE_PATH = "${JiveGlobals.getHomePath().resolve("conf").resolve("pushserver-apns.p8")}"
 
         private val properties = Property.values().associateBy({it}) { JiveGlobals.getProperty(it.key, null) }.toMutableMap()
     }


### PR DESCRIPTION
Replaced Openfire API usage that was deprecated in Openfire 4.8.0 and removed in 4.9.0.

This plugin is now compatible with Openfire 4.9.0 and requires 4.8.0 or later. No longer compatible with versions older than 4.8.0.

fixes #18